### PR TITLE
Fixed typo 'Five *sighns of code smell' to 'Five *signs of code smell'

### DIFF
--- a/Lists/CleanCode.md
+++ b/Lists/CleanCode.md
@@ -1,6 +1,6 @@
 # Clean Code
 - [Keeping `View Controllers` skinny and weakly-connected to models](https://cocoacasts.com/three-strategies-to-keep-view-controllers-skinny/)
-- [Five sighns of code smell](https://cocoacasts.com/five-signs-of-code-smell-in-swift/)
+- [Five signs of code smell](https://cocoacasts.com/five-signs-of-code-smell-in-swift/)
 - [Managing View Controllers With Container View Controllers](https://cocoacasts.com/managing-view-controllers-with-container-view-controllers/)
 - [Avoiding Massive View Controllers by refactoring.](https://medium.com/cocoaacademymag/avoiding-massive-view-controllers-by-refactoring-ffb6a55dfa42)
 


### PR DESCRIPTION
Fixed a typo in the link name 'Five *sighns of code smell' to 'Five *signs of code smell'