### PR TITLE
Add ARHeadsetKit and DL4S

### DIFF
--- a/Lists/ARKit.md
+++ b/Lists/ARKit.md
@@ -42,6 +42,7 @@ Navigation With Linear Algebra and Trig](https://medium.com/journey-of-one-thous
 
 ## Resources
 - [Hand-picked curation of the coolest stuff made with Apple's ARKit](http://www.madewitharkit.com)
+- [ARHeadsetKit: Using $5 Google Cardboard to replicate Hololens](https://github.com/philipturner/ARHeadsetKit)
 
 ## Documentation 📃
 - [ARKit Official Documentation](https://developer.apple.com/documentation/arkit)
@@ -49,6 +50,7 @@ Navigation With Linear Algebra and Trig](https://medium.com/journey-of-one-thous
 - [Building a Basic AR Experience](https://developer.apple.com/documentation/arkit/building_a_basic_ar_experience)
 - [Displaying an AR experience with Metal](https://developer.apple.com/documentation/arkit/displaying_an_ar_experience_with_metal)
 - [Official Human Interface Design Guidelines For Augmented Reality](https://developer.apple.com/ios/human-interface-guidelines/technologies/augmented-reality/)
+- [ARHeadsetKit Tutorials: Guide to a high-level framework for experimenting with AR](https://github.com/philipturner/arheadsetkit#tutorial-series)
 
 ## Code 💻
 - [Lava Project](https://github.com/arirawr/ARKit-FloorIsLava)
@@ -97,6 +99,7 @@ Navigation With Linear Algebra and Trig](https://medium.com/journey-of-one-thous
 - [Reimagining the power of Xcode's View Debugger for live debugging of AR or SceneKit apps](https://github.com/p-sun/ARPowerPanels)
 - [Building a Museum App with ARKit 2](https://www.raywenderlich.com/6957-building-a-museum-app-with-arkit-2)
 - [A crash course in Augmented Reality on iOS with ARKit](https://infinum.co/the-capsized-eight/crash-course-in-augmented-reality-on-ios-with-arkit)
+- [AR MultiPendulum](https://github.com/philipturner/ar-multipendulum)
 
 ## Video 📹
 - [Learn how to place objects in the world such as a cube and cup using ARKit, we go over the basics of ARKit](https://www.youtube.com/watch?v=tgPV_cRf2hA)

--- a/Lists/ARKit.md
+++ b/Lists/ARKit.md
@@ -39,6 +39,7 @@ Navigation With Linear Algebra and Trig](https://medium.com/journey-of-one-thous
 - [BUILDING VOICE RESPONSIVE AR APPS](https://martinmitrevski.com/2018/12/16/building-voice-responsive-ar-apps/)
 - [AUGMENTED REALITY ON IOS WITH ARKIT](https://martinmitrevski.com/2017/11/22/augmented-reality-on-ios-with-arkit/)
 - [Getting Started with ARKit](https://blog.novoda.com/getting-started-with-arkit/)
+- [Creating the First Affordable AR Headset Experience](https://philipturner.github.io/first-affordable-ar-headset)
 
 ## Resources
 - [Hand-picked curation of the coolest stuff made with Apple's ARKit](http://www.madewitharkit.com)

--- a/Lists/MachineLearning.md
+++ b/Lists/MachineLearning.md
@@ -29,6 +29,7 @@
 - [Keras - Deep Learning library for Python. Runs on TensorFlow, Theano, or CNTK.](https://github.com/fchollet/keras)
 - [coremltools is a python package for creating, examining, and testing models in the .mlmodel format. ](https://pypi.python.org/pypi/coremltools)
 - [5 Genius Python Deep Learning Libraries](https://elitedatascience.com/python-deep-learning-libraries#keras)
+- [DL4S - successor to Swift for TensorFlow](https://github.com/palle-k/DL4S)
 
 ## Video 📹
 - [Deep Learning: Keras Short Tutorial](https://www.youtube.com/watch?v=Tp3SaRbql4k)


### PR DESCRIPTION
I added several links about ARHeadsetKit in the AR section. I expect that you might request changes to a few addtions.

DL4S is in the process of a massive overhaul, becoming the first high-level ML training framework designed from the ground up for GPU acceleration with Metal. In the future, it will be hosted by the DL4S Team organization. Then, @palle-k's repository will have a notice saying the new version is in the new repository.